### PR TITLE
Fix post_class

### DIFF
--- a/wp-api-theming.php
+++ b/wp-api-theming.php
@@ -22,7 +22,7 @@ function wp_api_theming_posts_properties( $response ) {
 	);
 
 	// Add post classes.
-	$response->data['post_class'] = get_post_class( $response->data['id'] );
+	$response->data['post_class'] = get_post_class( '', $response->data['id'] );
 
 	// Add categories.
 	$categories = wp_api_theming_get_post_terms( $response->data['id'], 'category' );


### PR DESCRIPTION
The `get_post_class()` function requires you to include a blank argument for additional classes if you want to add a specific post ID: https://codex.wordpress.org/Function_Reference/get_post_class

Without this it won't return a specific post class.
